### PR TITLE
Adding Support for env Terminal Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ When creating a shell configuration, the path to the executable must be defined.
 - label: (Optional) Displayed in the shellLauncher dropdown menu
 - launchName: (Optional) Displayed in the terminal dropdown menu, note that this is static and replaces the default terminal name that changes based on the program being run
 - cwd: (Optional) A path for the current working directory to be used for the terminal
+- env: (Optional) Environment variables to be set for the terminal
 
 Here is an example shell which will launch `bash` as a login shell (`bash -l`) on Linux:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "shell-launcher",
     "displayName": "Shell launcher",
     "description": "Easily launch multiple shell configurations in the terminal",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "Tyriar",
     "icon": "images/icon.png",
     "bugs": {
@@ -64,7 +64,8 @@
                         "args": "string[]",
                         "label": "string",
                         "launchName": "string",
-                        "cwd": "string"
+                        "cwd": "string",
+                        "env": "string[]"
                     }
                 },
                 "shellLauncher.shells.linux": {
@@ -99,7 +100,8 @@
                         "args": "string[]",
                         "label": "string",
                         "launchName": "string",
-                        "cwd": "string"
+                        "cwd": "string",
+                        "env": "string[]"
                     }
                 },
                 "shellLauncher.shells.windows": {
@@ -128,7 +130,8 @@
                         "args": "string[]",
                         "label": "string",
                         "launchName": "string",
-                        "cwd": "string"
+                        "cwd": "string",
+                        "env": "string[]"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "shell-launcher",
     "displayName": "Shell launcher",
     "description": "Easily launch multiple shell configurations in the terminal",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "publisher": "Tyriar",
     "icon": "images/icon.png",
     "bugs": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ interface ShellConfig {
     label?: string;
     launchName?: string;
     cwd?: string;
+    env?: { [key: string]: string | null; };
 }
 
 interface ShellLauncherConfig {
@@ -84,7 +85,8 @@ export function activate(context: vscode.ExtensionContext) {
                 cwd: shell.cwd,
                 name: shell.launchName,
                 shellPath: shell.shell,
-                shellArgs: shell.args
+                shellArgs: shell.args,
+                env: shell.env
             };
             const terminal = vscode.window.createTerminal(terminalOptions);
             terminal.show();


### PR DESCRIPTION
This adds support for the `env` option that exists in the `TerminalOptions` interface. This allows users to add more complex custom terminals such as MSYS2 that require certain environment variables to be set in order to properly open in the correct working directory.

This is a common use case for this option, often used to integrate MSYS2 terminal with VSCode:

```json
    "shellLauncher.shells.windows": [
        {
            "shell": "C:\\msys64\\usr\\bin\\bash.exe",
            "label": "MSYS2",
            "args": ["--login", "-i"],
            "env": {
                "MSYSTEM": "MINGW64",
                "CHERE_INVOKING": "1"
            }
        }
    ]
```